### PR TITLE
(maint) Update Puppet VS Code Extension ID

### DIFF
--- a/site-modules/peadm_profile/.vscode/extensions.json
+++ b/site-modules/peadm_profile/.vscode/extensions.json
@@ -1,6 +1,6 @@
 {
   "recommendations": [
-    "jpogran.puppet-vscode",
+    "puppet.puppet-vscode",
     "rebornix.Ruby"
   ]
 }

--- a/site-modules/pecert_regen/.vscode/extensions.json
+++ b/site-modules/pecert_regen/.vscode/extensions.json
@@ -1,6 +1,6 @@
 {
   "recommendations": [
-    "jpogran.puppet-vscode",
+    "puppet.puppet-vscode",
     "rebornix.Ruby"
   ]
 }


### PR DESCRIPTION
This commit updates the configuration file to point to the official Puppet VS Code Extension `puppet.puppet-vscode`
